### PR TITLE
Post-rename updates: marketplace refs, new plugins, memex expansion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,8 +14,16 @@
       "source": "./plugins/claude"
     },
     {
+      "name": "cli",
+      "source": "./plugins/cli"
+    },
+    {
       "name": "github",
       "source": "./plugins/github"
+    },
+    {
+      "name": "markdown",
+      "source": "./plugins/markdown"
     },
     {
       "name": "memex",
@@ -24,6 +32,14 @@
     {
       "name": "nix",
       "source": "./plugins/nix"
+    },
+    {
+      "name": "todoist",
+      "source": "./plugins/todoist"
+    },
+    {
+      "name": "writing-style",
+      "source": "./plugins/writing-style"
     }
   ]
 }

--- a/plugins/claude/commands/issue/create.md
+++ b/plugins/claude/commands/issue/create.md
@@ -1,10 +1,10 @@
 ---
-description: Report an issue to the ungood/claude plugin marketplace
+description: Report an issue to the ungood/agents plugin marketplace
 allowed-tools: Bash(gh:*)
 argument-hint: '[title]'
 ---
 
-Report an issue to the ungood/claude plugin marketplace repository.
+Report an issue to the ungood/agents plugin marketplace repository.
 
 Follow these steps:
 
@@ -16,11 +16,11 @@ Follow these steps:
 
 2. **Create the issue in the marketplace repository**:
 
-   - Use `gh issue create` with the `-R` flag to target the marketplace repository `ungood/claude`
+   - Use `gh issue create` with the `-R` flag to target the marketplace repository `ungood/agents`
    - Use HEREDOC format for multiline bodies
    - Example:
      ```bash
-     gh issue create -R ungood/claude --title "Issue title" --body "$(cat <<'EOF'
+     gh issue create -R ungood/agents --title "Issue title" --body "$(cat <<'EOF'
      Issue description here
      EOF
      )"

--- a/plugins/cli/.claude-plugin/plugin.json
+++ b/plugins/cli/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "cli",
+  "description": "Quick references for common CLI tools",
+  "version": "0.1.0"
+}

--- a/plugins/cli/skills/tldr/SKILL.md
+++ b/plugins/cli/skills/tldr/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: tldr
+description: Look up concise command-line help using the tldr-pages project
+---
+
+## Overview
+
+`tldr` displays simple help pages for command-line tools from the tldr-pages project.
+
+More information: <https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md#command-line-interface>
+
+## Usage
+
+- Print the tldr page for a specific command:
+
+  ```text
+  tldr command
+  ```
+
+- Print the tldr page for a specific subcommand:
+
+  ```text
+  tldr command subcommand
+  ```
+
+- Print the tldr page for a command from a specific platform:
+
+  ```text
+  tldr --platform android|cisco-ios|common|dos|freebsd|linux|netbsd|openbsd|osx|sunos|windows command
+  ```
+
+- Update the local cache of tldr pages:
+
+  ```text
+  tldr --update
+  ```
+
+- List all pages for the current platform and common:
+
+  ```text
+  tldr --list
+  ```

--- a/plugins/cli/skills/tree/SKILL.md
+++ b/plugins/cli/skills/tree/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: tree
+description: Show directory structure as a tree visualization
+---
+
+## Overview
+
+`tree` shows the contents of directories in a tree format, making it easy to visualize directory structure and file hierarchy.
+
+More information: <https://manned.org/tree>
+
+## Usage
+
+- Print files and directories up to `num` levels of depth (where 1 means the current directory):
+
+  ```text
+  tree -L num
+  ```
+
+- Print directories only:
+
+  ```text
+  tree -d
+  ```
+
+- Print hidden files too with colorization on:
+
+  ```text
+  tree -a -C
+  ```
+
+- Print the tree without indentation lines, showing the full path instead (use `-N` to not escape non-printable characters):
+
+  ```text
+  tree -i -f
+  ```
+
+- Print the size of each file and the cumulative size of each directory, in human-readable format:
+
+  ```text
+  tree -s -h --du
+  ```
+
+- Print files within the tree hierarchy, using a wildcard (glob) pattern, and pruning out directories that don't contain matching files:
+
+  ```text
+  tree -P '*.txt' --prune
+  ```
+
+- Print directories within the tree hierarchy, using the wildcard (glob) pattern, and pruning out directories that aren't ancestors of the wanted one:
+
+  ```text
+  tree -P directory_name --matchdirs --prune
+  ```
+
+- Print the tree ignoring the given directories:
+
+  ```text
+  tree -I 'directory_name1|directory_name2'
+  ```

--- a/plugins/markdown/.claude-plugin/plugin.json
+++ b/plugins/markdown/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "markdown",
+  "description": "Markdown formatting conventions aligned with rumdl linter",
+  "version": "0.1.0"
+}

--- a/plugins/markdown/skills/markdown/SKILL.md
+++ b/plugins/markdown/skills/markdown/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: markdown
+description: Markdown formatting conventions — heading/list/emphasis style, frontmatter, and link format (aligned with rumdl linter config)
+---
+
+## Formatting Rules
+
+These match the rumdl linter config (`.rumdl.toml`). Run `rumdl <file>` to check.
+
+### Headings
+
+- **ATX style only** — use `## Heading`, not underline style (MD003)
+- Start content at `##` level — no `#` headers in file body (Obsidian uses filename as title)
+
+### Lists
+
+- **Dash markers** — use `- item`, not `*` or `+` (MD004)
+
+### Emphasis and Bold
+
+- **Underscore for italic**: `_italic_`, not `*italic*` (MD049)
+- **Asterisk for bold**: `**bold**`, not `__bold__` (MD050)
+
+### Line Length
+
+- Soft target of 120 characters for non-prose lines (code blocks, tables)
+- Let editors handle visual wrapping for prose
+
+## Frontmatter
+
+- YAML fences (`---`) at the top of the file for structured properties
+- Keep frontmatter minimal — omit empty fields rather than leaving them blank
+- Common properties: `tags`, `aliases`
+
+## Links
+
+- Use **wikilinks** (`[[Note Name]]`) for internal vault links
+- Aliases: `[[Note Name|display text]]`
+- Heading links: `[[Note Name#Section]]`
+- Standard markdown links (`[text](url)`) for external URLs only

--- a/plugins/memex/.claude-plugin/plugin.json
+++ b/plugins/memex/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memex",
-  "description": "Two-tier memory system and task management for personal productivity",
-  "version": "0.1.0"
+  "description": "Obsidian vault management — memory system, task management, people files, and CLI reference",
+  "version": "0.2.0"
 }

--- a/plugins/memex/skills/obsidian/SKILL.md
+++ b/plugins/memex/skills/obsidian/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: obsidian
+description: Obsidian CLI reference — control the Obsidian app from the terminal for file operations, search, properties, tasks, and more
+---
+
+## Overview
+
+Obsidian ships a built-in CLI (`obsidian`) that controls the running Obsidian app from the terminal. It requires Obsidian to be running — if it's not, the first command launches it.
+
+Full docs: <https://help.obsidian.md/cli>
+
+Run `obsidian help` or `obsidian help <command>` for inline reference.
+
+## Syntax
+
+```sh
+obsidian <command> [param=value ...] [flags]
+```
+
+- **Parameters** take values: `name="My Note"` (quote values with spaces)
+- **Flags** are boolean switches: `open`, `overwrite`, `newtab`
+- Use `\n` for newlines and `\t` for tabs in content values
+- Add `--copy` to any command to copy output to clipboard
+
+### Targeting a vault
+
+If CWD is inside a vault, that vault is used. Otherwise the active vault is used. Override with:
+
+```sh
+obsidian vault=memex <command>
+```
+
+### Targeting a file
+
+Most commands accept `file` and `path`:
+
+- `file=<name>` — resolves like wikilinks (name only, no path or extension needed)
+- `path=<path>` — exact path from vault root, e.g. `50 Journal/2026/03-Mar/2026-03-08 Daily Journal.md`
+
+If neither is given, commands default to the active file.
+
+**The CLI does not accept positional arguments.** Always use named parameters:
+
+```sh
+obsidian open file="Notification Routing Plan"     # correct
+obsidian open "Notification Routing Plan.md"       # WRONG — will error
+```
+
+## When to Use CLI vs. Direct File Operations
+
+Most agent work should use direct file tools (Read, Write, Edit, Glob, Grep) — they're faster and don't require Obsidian to be running.
+
+**Use the Obsidian CLI for:**
+
+- `move` / `rename` — updates wikilinks across the vault (never use `mv`/`git mv`)
+- `open` — show a note to the user in Obsidian
+- `daily` — open or append to today's daily note
+- `property:set` / `property:remove` — safely modify frontmatter properties
+- `search` / `search:context` — Obsidian-native search (respects search operators)
+- `tasks` / `task` — list and toggle tasks vault-wide
+- `base:query` — query Bases views
+- `backlinks` / `links` / `orphans` — link graph queries
+- `tags` — vault-wide tag listing with counts
+- `create` with `template=` — create a note from an Obsidian template
+
+**Use direct file tools for:**
+
+- Reading note content (Read tool — faster, gives line numbers)
+- Writing or editing note content (Write/Edit tools)
+- Finding files by name pattern (Glob tool)
+- Searching file content by regex (Grep tool)
+
+## Key Commands
+
+### Files
+
+```sh
+obsidian open file="Note Name"              # open in Obsidian
+obsidian open file="Note Name" newtab       # open in new tab
+obsidian create name="Note" content="# Title\n\nBody"
+obsidian create name="Note" template=Travel open  # from template
+obsidian move file="Old Name" to="new/path.md"    # updates all links
+obsidian rename file="Old Name" name="New Name"   # updates all links
+obsidian delete file="Note"                       # moves to trash
+obsidian read file="Note"                         # print contents
+obsidian append file="Note" content="new line"
+obsidian prepend file="Note" content="new line"
+```
+
+### Daily Notes
+
+```sh
+obsidian daily                              # open today's daily note
+obsidian daily:path                         # get daily note path
+obsidian daily:read                         # print daily note contents
+obsidian daily:append content="- [ ] Task"  # append to daily note
+```
+
+### Search
+
+```sh
+obsidian search query="meeting notes"                 # file name matches
+obsidian search query="meeting notes" total           # just the count
+obsidian search:context query="TODO" format=json      # with line context
+```
+
+### Properties
+
+```sh
+obsidian properties file="Note"                          # list properties on a file
+obsidian property:set file="Note" name=status value=active type=text
+obsidian property:read file="Note" name=status
+obsidian property:remove file="Note" name=status
+```
+
+### Tags
+
+```sh
+obsidian tags                              # list all tags
+obsidian tags counts sort=count            # sorted by frequency
+obsidian tag name=project verbose          # files with this tag
+```
+
+### Tasks
+
+```sh
+obsidian tasks todo                        # all incomplete tasks
+obsidian tasks daily                       # tasks from daily note
+obsidian tasks file="Note" verbose         # with file paths + line numbers
+obsidian task ref="Recipe.md:8" toggle     # toggle a specific task
+obsidian task daily line=3 done            # complete daily note task
+```
+
+### Links
+
+```sh
+obsidian backlinks file="Note"             # incoming links
+obsidian links file="Note"                 # outgoing links
+obsidian orphans                           # files with no incoming links
+obsidian unresolved                        # broken links
+```
+
+### Bases
+
+```sh
+obsidian bases                             # list .base files
+obsidian base:query file="Tasks" format=json
+obsidian base:query file="Tasks" view="Active" format=csv
+obsidian base:create file="Tasks" name="New Item" content="# New Item"
+```
+
+### Plugins
+
+```sh
+obsidian plugins filter=community versions  # list installed plugins
+obsidian plugin:enable id=dataview
+obsidian plugin:disable id=dataview
+```
+
+### Vault Info
+
+```sh
+obsidian vault                             # name, path, file/folder counts
+obsidian files total                       # file count
+obsidian files folder="20 Projects"        # list files in a folder
+obsidian folders                           # list all folders
+```
+
+## Installed Plugins
+
+### Obsidian Git
+
+Automated git backup for the vault.
+
+- **Auto-push interval:** 60 minutes
+- **Auto-pull on boot:** enabled
+- **Commit message format:** `vault backup: {{date}}` (`YYYY-MM-DD HH:mm:ss`)
+
+The agent should not interfere with obsidian-git's commit cycle. Agent changes get picked up on the next auto-push. Manual `git commit` is fine for batch operations.
+
+### Daily Notes Configuration
+
+- **Format:** `YYYY/MM-MMM/YYYY-MM-DD Daily Journal`
+- **Folder:** `50 Journal`
+- **Template:** `40 Resources/Templates/daily-review`
+
+Produces paths like: `50 Journal/2026/03-Mar/2026-03-08 Daily Journal.md`

--- a/plugins/memex/skills/people/SKILL.md
+++ b/plugins/memex/skills/people/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: people
+description: Create, update, and manage people files in the vault's 40 Resources/People/ directory
+---
+
+## Overview
+
+People files live in `40 Resources/People/`. Each file represents a person and contains structured properties plus freeform notes (meeting notes, observations, etc.).
+
+## File Conventions
+
+### Filename
+
+Use the person's **preferred name** — the name they go by day-to-day:
+
+- Full preferred name: `Sébastien Laporte.md`, `Michael Darwish.md`
+- Nickname-based if that's what everyone uses: `MG.md`, `GG.md`
+
+### Structure
+
+Every people file follows this layout:
+
+```markdown
+# Preferred Name
+
+**Full Name:** Legal / formal name (only if different from header)
+**Nickname:** Short name or initials (only if commonly used)
+**Email:** user@example.com
+**Role:** Job title
+**Team:** Primary team name
+**Team Role:** manager | technical_lead | product_lead | product_designer | qa | member | honorary_member
+**Manager:** [[Manager Name]]
+**Location:** City or City, Country
+**Status:** Met | Scheduled | Pending | Not started
+
+## Notes
+
+Freeform content: meeting notes (dated with ### headings), observations, context, etc.
+```
+
+### Property rules
+
+- Omit any property that has no value — don't include empty fields.
+- **Manager** should be an Obsidian wikilink: `[[Name]]`
+- **Team** is the team name. If someone is on multiple teams, list the primary one and mention others in notes.
+- **Team Role** indicates their role within the team structure (manager, tech lead, etc.), not their job title.
+- **Status** tracks your relationship: `Met` (had a 1:1), `Scheduled` (meeting booked), `Pending` (intend to meet), `Not started` (no plans yet).
+
+## Key Patterns
+
+### Creating a new person file
+
+1. Use their preferred name as the filename.
+2. Populate all available properties.
+3. Set Status to `Not started` unless specified otherwise.
+
+### After a meeting
+
+Add a dated section under `## Notes`:
+
+```markdown
+### January 15, 2026
+
+- Key discussion points
+- Action items
+- Observations
+```
+
+## Troubleshooting
+
+- **Person not in any directory**: Create the file manually with whatever info is available.
+- **Duplicate people across teams**: Some people appear on multiple teams. Use their primary team for the Team property.

--- a/plugins/todoist/.claude-plugin/plugin.json
+++ b/plugins/todoist/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "todoist",
+  "description": "Interact with Todoist via MCP for task management",
+  "version": "0.1.0"
+}

--- a/plugins/todoist/skills/todoist/SKILL.md
+++ b/plugins/todoist/skills/todoist/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: todoist
+description: Interact with Todoist via the MCP server to query, create, update, and complete tasks
+---
+
+## Overview
+
+Todoist is connected via an MCP server. The MCP tools are available directly — no CLI needed. Configure the Todoist MCP in `.claude/settings.local.json`:
+
+```json
+{
+  "mcpServers": {
+    "todoist": {
+      "type": "url",
+      "url": "https://ai.todoist.net/mcp"
+    }
+  }
+}
+```
+
+## Available MCP Tools
+
+The Todoist MCP server exposes tools for task and project management. Common tools include:
+
+- **Get tasks** — Retrieve tasks with optional filters (today, overdue, by project, by priority)
+- **Create task** — Add a new task with content, due date, priority, project, and labels
+- **Update task** — Modify an existing task's content, due date/time, priority, or project
+- **Complete task** — Mark a task as done
+- **Get projects** — List all projects
+
+## Key Patterns
+
+### Querying today's tasks
+
+Fetch tasks due today and any overdue items. Look for filter parameters like `filter` (uses Todoist filter syntax) or date-based parameters.
+
+Useful Todoist filter strings:
+
+- `today` — tasks due today
+- `overdue` — past-due tasks
+- `today | overdue` — both
+- `p1` — priority 1 (urgent)
+- `p1 | p2` — high priority
+- `no date` — unscheduled tasks
+- `#ProjectName` — tasks in a specific project
+- Combine with `&` (AND) and `|` (OR): `(today | overdue) & p1`
+
+### Setting due dates
+
+Update a task's due string using Todoist natural language:
+
+- `today` — due today (no specific time)
+- `today at 10:00` — due today at 10:00 AM
+- `tomorrow` — due tomorrow
+- `next week` — due next Monday
+- `Feb 16` — specific date
+- `every Monday` — recurring
+
+### Rescheduling patterns
+
+Common during grooming and reviews:
+
+- Move overdue to today: set due string to `today`
+- Defer to tomorrow: `tomorrow`
+- Defer to next week: `next Monday`
+- Remove due date: clear the due string (someday/unscheduled)
+
+## Operating Constraints
+
+- **Read operations** (get tasks, get projects, list labels): Execute freely, no approval needed
+- **Write operations** (create, update, complete, delete tasks): Always require explicit user approval before executing
+- **Batch updates**: When updating multiple tasks (e.g., scheduling), present the full list of changes first and get a single approval for the batch
+- Keep task queries focused — don't dump the entire backlog. Filter to what's relevant for the current context.

--- a/plugins/writing-style/.claude-plugin/plugin.json
+++ b/plugins/writing-style/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "writing-style",
+  "description": "Enforces clear, human writing style and eliminates AI-isms",
+  "version": "0.1.0"
+}

--- a/plugins/writing-style/skills/writing-style/SKILL.md
+++ b/plugins/writing-style/skills/writing-style/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: writing-style
+description: Enforces clear, human writing style. Load this skill for all writing — journal entries, summaries, vault notes, and conversational output.
+---
+
+## Overview
+
+Write like a competent person talking to another competent person. This skill defines what to avoid (AI-isms) and what to aim for (clear, direct prose). Load it for any writing task.
+
+## AI-isms — The Full Catalog
+
+AI-generated text has recognizable fingerprints. These fall into six categories: word choice, phrases, structure, tone, rhetoric, and sentence patterns. Avoid all of them.
+
+### 1. Overused Words
+
+Words that appear at statistically improbable rates in AI text. Most are real words used incorrectly — not banned from English, but so overrepresented by models that they've become tells.
+
+**Dead giveaways** (never use):
+delve, tapestry, landscape (metaphorical), navigate (metaphorical), foster, nuanced, multifaceted, underscores, pivotal, realm, testament, beacon, cornerstone, embark, myriad, plethora, paramount, interplay, intricacies, spearhead, bolster, fortify, catapult, synergy
+
+**Overused modifiers** (find a specific word instead):
+comprehensive, innovative, cutting-edge, robust, seamless, holistic, dynamic, transformative, groundbreaking, noteworthy, remarkable, invaluable, indispensable
+
+**Corporate verbs** (say what you mean):
+leverage (verb), utilize (use), streamline, optimize (unless actual optimization), empower, facilitate, catalyze, harness, cultivate (metaphorical), curate (unless actual curation), champion (verb, in corporate contexts), ideate, operationalize, action (verb)
+
+**Filler adverbs** (cut entirely — they add nothing):
+notably, importantly, crucially, interestingly, remarkably, incredibly, truly, essentially, fundamentally, undeniably, undoubtedly, certainly
+
+**Connector bloat** (use sparingly if at all):
+furthermore, moreover, additionally, consequently, nevertheless, in addition, similarly, likewise, conversely
+
+### 2. Banned Phrases
+
+Cut these entirely or replace with direct language.
+
+**Sycophantic openers:**
+"Great question!", "That's a really interesting point!", "Absolutely!", "Of course!", "I'd be happy to help!", "Sure thing!", "What a great idea!", "Excellent observation!"
+
+**Corporate filler:**
+"It's worth noting that...", "It's important to remember...", "At the end of the day...", "Moving forward...", "In terms of...", "That being said...", "With that in mind...", "Let's unpack this...", "Let's dive in...", "Let's break this down...", "When it comes to..."
+
+**The "In today's..." opener:**
+"In today's fast-paced world...", "In today's rapidly evolving landscape...", "In an era of...", "In the ever-changing world of..."
+
+**AI self-reference:**
+"As an AI...", "As a large language model...", "As your assistant...", "I don't have personal experiences, but...", "While I can't \[human thing\]..."
+
+**Permission-granting closers:**
+"Hope this helps!", "Let me know if you have any other questions!", "Feel free to ask if you need anything else!", "Happy to help further!", "Don't hesitate to reach out!"
+
+**False profundity:**
+"At its core, \[X\] is about \[Y\]", "It's not just about X; it's about Y", "\[Topic\] is a double-edged sword", "The answer lies in...", "This raises an important question...", "Remember, \[obvious truism\]"
+
+**Performative empathy:**
+"I understand this can be frustrating...", "I can see why you'd feel that way...", "That's a valid concern...", "Your feelings are completely understandable..."
+
+### 3. Structural Tells
+
+**The triple-point list.** AI loves grouping everything into exactly three bullet points. If you have two points, say two. If you have seven, say seven. Don't compress to three because it feels tidy.
+
+**The sandwich.** Intro paragraph stating what you'll say, bullet points saying it, summary paragraph restating what you said. The intro and summary are redundant — cut one or both.
+
+**Restating the question.** The user just said it. Don't echo "You're asking about X" before answering.
+
+**Meta-commentary.** "Let me break this down...", "I'll analyze this step by step...", "Here's what I found...", "Let me walk you through this..." — just do the thing.
+
+**The "Overall" closer.** A final paragraph starting with "Overall," "In summary," "In conclusion," or "To sum up" that restates the preceding content. If the content is clear, no summary is needed.
+
+**Uniform paragraph length.** AI tends to produce paragraphs of nearly identical length. Real writing has varied rhythm — a one-sentence paragraph hits different than a five-sentence one.
+
+**Headers as complete sentences or questions.** "What Makes This Approach Effective?" is an AI header. "Approach" or "Effectiveness" is a human one.
+
+**Premature structure.** Not every response needs headers, bullets, and sections. A short paragraph is often the right format. Match the structure to the content's complexity.
+
+### 4. Tonal Tells
+
+**Relentless positivity.** AI defaults to enthusiasm. Not everything is exciting, powerful, or a great opportunity. Neutral is a valid tone.
+
+**Universal agreeableness.** Real advisors disagree, push back, flag problems. If you never say "that's a bad idea," you're not advising — you're validating.
+
+**Diplomatic to the point of meaninglessness.** "There are potential challenges to consider" means nothing. "This will break the deploy pipeline" means something.
+
+**Treating everything as equally important.** Varying emphasis signals judgment. If three of five items are routine and two are urgent, the writing should reflect that.
+
+**Manufactured enthusiasm about mundane topics.** Not everything deserves exclamation points or superlatives. A cron job is a cron job.
+
+**Excessive hedging.** "This might potentially be something worth considering exploring" — just say what you think. One qualifier per claim is enough.
+
+**"Both sides" framing.** When one option is clearly better, say so. Don't manufacture false balance.
+
+### 5. Rhetorical Tells
+
+**The tapestry metaphor.** "The rich tapestry of...", "woven into the fabric of..." — AI reaches for textile metaphors constantly. Avoid.
+
+**Inspirational closers nobody asked for.** Ending a technical answer with "The possibilities are endless!" or "The future is bright!" — don't.
+
+**The false-choice reframe.** "It's not about X or Y — it's about both" or "The real question isn't X, it's Y." This is a rhetorical move that sounds smart but usually isn't.
+
+**Anthropomorphizing abstractions.** "This approach invites us to consider...", "The data tells a compelling story...", "This framework speaks to..."
+
+**Escalating adjective chains.** "This innovative, comprehensive, forward-thinking approach..." — pick one adjective or none.
+
+**The "whether you're... or..." construction.** "Whether you're a beginner or an expert..." — this is marketing copy, not communication.
+
+### 6. Sentence-Level Tells
+
+**"This" without a referent.** "This is important because..." — what is "this"? Name it.
+
+**Parallel structure in everything.** Some parallelism is good. Every list item starting with the same part of speech, every paragraph following the same pattern, is robotic.
+
+**The short-long alternation.** Short declarative sentence. Then a longer explanatory sentence that unpacks the first one with additional context and nuance. Repeated for every point. Real prose varies more than this.
+
+**"Not only X, but also Y."** Technically correct. In practice, an AI tell because models reach for this construction constantly.
+
+**Starting sentences with "Importantly," or "Crucially,".** These are almost always filler. If something is important, its importance should be clear from context.
+
+**Noun phrase pileups.** "This comprehensive, data-driven, user-centric approach to streamlined, efficient workflow optimization..." — this is word salad. Break it up or simplify.
+
+**Sentence fragments as descriptions.** "Division-wide technical architecture for the Asset Intelligence system." is not a sentence — it's a label. Write "This document describes the division-wide technical architecture..." instead. Fragments are fine in conversation ("Not bad.") but not as topic sentences, section openers, or document descriptions. If it would need a period to look finished but doesn't have a verb, it's a fragment pretending to be prose.
+
+## What Good Writing Looks Like
+
+- **Concise above all.** Say it once, say it short, move on. If a section can lose a paragraph without losing meaning, lose the paragraph. If a paragraph can be a sentence, make it a sentence.
+- **State, don't sell.** Describe what something is and how it works. Don't justify, argue merits, or preempt objections — unless asked. "Devbox wraps Nix in JSON config" is enough. Adding "which reduces adoption friction" is selling.
+- **One point per paragraph.** If you're making the same point with different words, pick the strongest version and cut the rest.
+- **Direct.** Lead with the answer or recommendation. Context after, if needed.
+- **Specific.** "You have 12 overdue tasks, 8 personal admin" beats "quite a few overdue tasks across various categories."
+- **Honest.** If something isn't working, say so. Don't manufacture enthusiasm.
+- **Matched register.** Jason writes informally with technical precision. Contractions, fragments, starting sentences with "And" or "But" — all fine.
+- **Concrete.** Prefer words that create mental images over abstract nouns.
+- **Economical.** Not every transition needs a connector. If the next point follows obviously, just state it.
+- **Varied rhythm.** Mix sentence lengths. A two-word sentence after a complex one creates emphasis. Monotonous cadence is a tell.
+
+## Structural Rules
+
+- Don't repeat the question back.
+- Don't hedge everything. State your position. Say "I'm not sure" once if uncertain, then give your best answer.
+- Don't use lists where prose works. Lists are for actionable items, choices, sequences — not for expressing one thought from three angles.
+- Don't add meta-commentary. Just do the work.
+- Don't soften every opinion. Jason has final say. Direct recommendations beat hedged suggestions.
+
+## Formatting (CLI Output)
+
+- No markdown tables (render poorly in terminals)
+- Numbered lists or indented blocks for structured data
+- Group by category with clear headers
+- One or two short lines per item
+- Simple numbered references when asking for approval
+
+## When to Load This Skill
+
+Load this skill for:
+
+- Journal entries and daily/weekly/monthly reviews
+- Summaries and long-form vault content
+- Drafting communications
+- Any response longer than a couple of sentences
+
+The rules also apply to conversational output, but the agent system prompts handle that with a condensed version. This skill is the full reference.


### PR DESCRIPTION
## Summary

Three commits bundled after the `ungood/claude` → `ungood/agents` repo rename:

- **Update marketplace references** — fix `ungood/claude` → `ungood/agents` in `plugins/claude/commands/issue/create.md` (4 references)
- **Add 4 new plugins** — `cli` (tldr, tree skills), `markdown` (formatting conventions), `todoist` (MCP-backed task management), `writing-style` (anti-AI-isms style guide); all registered in `marketplace.json`
- **Expand memex** — add `obsidian` (CLI reference) and `people` (people-file conventions) skills; bump memex to v0.2.0 with broader description

## Test plan

- [ ] Confirm marketplace.json is valid and lists all 8 plugins
- [ ] Verify each new plugin's `plugin.json` and `SKILL.md` parse correctly
- [ ] Spot-check that `/claude:issue:create` references the new repo name